### PR TITLE
Fixed bug in YearBubbleSort

### DIFF
--- a/MovieSeller.cpp
+++ b/MovieSeller.cpp
@@ -275,7 +275,16 @@ void MovieSeller::YearbubbleSort()
         {
                 for (int j = 0;j< hashTable[i].size();j++)
                 {
-                    Years.push_back((hashTable[i])[j]->year);
+                    int temp = (hashTable[i])[j]->year;
+                    bool found = false;
+                    for(int k = 0; k < Years.size(); k++){
+                        if(Years[k] == temp){
+                            found = true;
+                        }
+                    }
+                    if(found == false){
+                        Years.push_back((hashTable[i])[j]->year);
+                    }
                 }
         }
 


### PR DESCRIPTION
Issue was that the year of every movie got added to the Years vector, even if it was already in there. Added an if statement to make sure each year only got added once.
